### PR TITLE
:sparkles: secret 密文传输支持

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     "fastapi",
     "herta",
     "hertavilla",
+    "Pubkey",
     "pypi",
     "retcode",
     "sourcery",

--- a/hertavilla/apis/base.py
+++ b/hertavilla/apis/base.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
 import logging
 from typing import Any, Literal
+import warnings
 
-from hertavilla.exception import HTTPStatusError, raise_exception
+from hertavilla.exception import (
+    HTTPStatusError,
+    PubkeyNoneWarning,
+    raise_exception,
+)
 
 from aiohttp import ClientSession
 
@@ -12,18 +19,39 @@ BASE_API = "https://bbs-api.miyoushe.com/vila/api/bot/platform"
 
 
 class _BaseAPIMixin:
-    def __init__(self, bot_id: str, secret: str):
+    def __init__(
+        self,
+        bot_id: str,
+        secret: str,
+        pub_key: str | None = None,
+    ):
         self.bot_id = bot_id
         self.secret = secret
+        self.pub_key = pub_key
+        if pub_key is None:
+            warnings.warn(
+                "Pubkey is None. You're using unencrypted secret. "
+                "Unencrypted secret will be deprecated after August 8, 2023",
+                stacklevel=3,
+                category=PubkeyNoneWarning,
+            )
 
     def _make_header(self, villa_id: int) -> dict[str, str]:
+        if self.pub_key is not None:
+            secret = hmac.new(
+                self.pub_key.encode(),
+                self.secret.encode(),
+                hashlib.sha256,
+            ).hexdigest()
+        else:
+            secret = self.secret
         return {
             "x-rpc-bot_id": self.bot_id,
-            "x-rpc-bot_secret": self.secret,
+            "x-rpc-bot_secret": secret,
             "x-rpc-bot_villa_id": str(villa_id),
         }
 
-    async def base_request(  # noqa: PLR0913
+    async def base_request(
         self,
         api: str,
         method: Literal["POST"] | Literal["GET"],

--- a/hertavilla/bot.py
+++ b/hertavilla/bot.py
@@ -75,12 +75,12 @@ class VillaBot(
         bot_id: str,
         secret: str,
         callback_endpoint: str,
+        pub_key: str | None = None,
         bot_info: "Template" | None = None,
     ) -> None:
         from hertavilla.event import SendMessageEvent
 
-        self.bot_id = bot_id
-        self.secret = secret
+        super().__init__(bot_id, secret, pub_key)
         self._bot_info = bot_info
         self.callback_endpoint = callback_endpoint
         self.handlers: list[Handler] = []

--- a/hertavilla/exception.py
+++ b/hertavilla/exception.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 
+class PubkeyNoneWarning(Warning):
+    ...
+
+
 class SDKException(Exception):
     ...
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ select = [
   "B",        # flake8-bugbear
   "ASYNC",    # flake8-async
 ]
-
+ignore = ["PLR0913"]
 allowed-confusables = ["，", "。", "（", "）", "；"]
 
 [tool.ruff.isort]


### PR DESCRIPTION
`VillaBot` 新增参数 `pub_key`，用来传入开发平台提供的 `pub_key`。此参数为可选，2023/8/8 之后，此参数会改为必填。目前未填写此项会提供一个警告

```text
PubkeyNoneWarning: Pubkey is None. You're using unencrypted secret. Unencrypted secret will be deprecated after August 8, 2023
```